### PR TITLE
Fix Android app crashes when opening cards and tapping view more

### DIFF
--- a/mobile-app/src/components/DealCard.tsx
+++ b/mobile-app/src/components/DealCard.tsx
@@ -102,7 +102,7 @@ function DealCard({ deal, onPress, onLike, onClaim, onRemind, onLocationPress, i
         />
         {/* Discount Badge */}
         <View style={styles.discountBadge}>
-          <Text style={styles.discountText}>{deal.discount}%</Text>
+          <Text style={styles.discountText}>{typeof deal.discount === 'number' ? Math.round(deal.discount) : 0}%</Text>
           <Text style={styles.offText}>OFF</Text>
         </View>
 
@@ -190,9 +190,9 @@ function DealCard({ deal, onPress, onLike, onClaim, onRemind, onLocationPress, i
         {/* Price Section */}
         <View style={styles.priceRow}>
           <Text style={styles.discountedPrice} numberOfLines={1}>
-            ${deal.discountedPrice.toFixed(2)}
+            ${typeof deal.discountedPrice === 'number' ? deal.discountedPrice.toFixed(2) : '0.00'}
           </Text>
-          {deal.originalPrice > 0 && (
+          {typeof deal.originalPrice === 'number' && deal.originalPrice > 0 && (
             <Text style={styles.originalPrice} numberOfLines={1}>
               ${deal.originalPrice.toFixed(2)}
             </Text>

--- a/mobile-app/src/components/DealCardLandscape.tsx
+++ b/mobile-app/src/components/DealCardLandscape.tsx
@@ -82,7 +82,7 @@ function DealCardLandscape({ deal, onPress, onLike, onRemind, onLocationPress, i
         />
         {/* Discount Badge */}
         <View style={styles.discountBadge}>
-          <Text style={styles.discountText}>{deal.discount}%</Text>
+          <Text style={styles.discountText}>{typeof deal.discount === 'number' ? Math.round(deal.discount) : 0}%</Text>
           <Text style={styles.offText}>OFF</Text>
         </View>
 
@@ -124,9 +124,9 @@ function DealCardLandscape({ deal, onPress, onLike, onRemind, onLocationPress, i
         {/* Price Section */}
         <View style={styles.priceRow}>
           <Text style={styles.discountedPrice} numberOfLines={1}>
-            ${deal.discountedPrice.toFixed(2)}
+            ${typeof deal.discountedPrice === 'number' ? deal.discountedPrice.toFixed(2) : '0.00'}
           </Text>
-          {deal.originalPrice > 0 && (
+          {typeof deal.originalPrice === 'number' && deal.originalPrice > 0 && (
             <Text style={styles.originalPrice} numberOfLines={1}>
               ${deal.originalPrice.toFixed(2)}
             </Text>

--- a/mobile-app/src/screens/RedemptionScreen.tsx
+++ b/mobile-app/src/screens/RedemptionScreen.tsx
@@ -276,7 +276,7 @@ export default function RedemptionScreen({ navigation }: RedemptionScreenProps) 
               <Text style={styles.detailValue}>
                 {claimDetails.discount_type === 'percentage'
                   ? `${claimDetails.discount_value}%`
-                  : `$${claimDetails.discount_value.toFixed(2)}`}
+                  : `$${typeof claimDetails.discount_value === 'number' ? claimDetails.discount_value.toFixed(2) : '0.00'}`}
               </Text>
             </View>
 


### PR DESCRIPTION
Added defensive type checks before calling .toFixed() on price values to prevent crashes when API returns null/undefined/NaN values.

Changes:
- DealCard.tsx: Add type safety for discountedPrice, originalPrice, and discount
- DealCardLandscape.tsx: Add type safety for price and discount fields
- RedemptionScreen.tsx: Add type safety for discount_value field

Fixes crashes that occur when:
- Opening offer cards from any section
- Tapping "View More" to see full offer lists
- Viewing redemption details

Root cause: .toFixed() method called on non-number values crashes the app
Solution: Check typeof value === 'number' before calling .toFixed()